### PR TITLE
Actualización de vistas del reproductor

### DIFF
--- a/DrgonBallWiki/View/Cards/CardListAudioView.swift
+++ b/DrgonBallWiki/View/Cards/CardListAudioView.swift
@@ -16,25 +16,43 @@ struct CardListAudioView: View {
     @State private var showModal = false
     @State private var showWinAudio = false
     @State var mostrarButton = false
-    
+    @Binding var showListAudio: Bool
     @Namespace var winAnimation
     
     var body: some View {
         NavigationStack{
-            ZStack{
-            
-                VStack{
-                    HStack{
+            VStack{
+                List {
+                    VStack(alignment: .leading){
                         
-                        Spacer()
-                    }
-                    List {
-                        VStack(alignment: .leading){
-                            ForEach(viewModel.arrayOfSounds, id: \.self) { sound in
-                                Text(sound.title)
-                                    .modifier(StyleViewFont(size: 30, color: .red))
-                                    .padding()
-                                    .onTapGesture {
+                        HStack(alignment: .firstTextBaseline){
+                            Spacer()
+                            Text("Lista de reproducciones")
+                                .modifier(StyleViewFont(size: 30, color: .red))
+                                .shadow(color: .cyan, radius: 5)
+                            Spacer()
+                            Button(action: {
+                                withAnimation(.spring(response: 0.3, dampingFraction: 1)) {
+                                    showListAudio = false
+                                }
+                            }, label: {
+                                Image(systemName: "xmark")
+                                    .font(.footnote)
+                                    .fontWeight(.semibold)
+                                    .foregroundStyle(Color.white)
+                                    .padding(7)
+                                    .background {
+                                        RoundedRectangle(cornerRadius: 100)
+                                            .fill(.ultraThinMaterial)
+                                    }.padding()
+                            })
+                        }
+                        Divider()
+                        ForEach(viewModel.arrayOfSounds, id: \.self) { sound in
+                            Text(sound.title)
+                                .modifier(StyleViewFont(size: 30, color: .red))
+                                .padding()
+                                .onTapGesture {
                                     audioL = sound.title
                                     covers = sound.imageCoves
                                     // showModal = true
@@ -43,29 +61,28 @@ struct CardListAudioView: View {
                                         showWinAudio = true
                                     }
                                 }
-                                
-                            }
-                        }.listRowBackground(Color.clear)
-                            .background{
-                                RoundedRectangle(cornerRadius: 15, style: .continuous)
-                                    .fill(.ultraThinMaterial)
-                            }
-                                .frame(width: 300, height: 400, alignment: .center)
-                    }
-                    
-                    .listStyle(PlainListStyle())
-                }
+                            
+                        }
+                    }.listRowBackground(Color.clear)
+                        .background{
+                            RoundedRectangle(cornerRadius: 15, style: .continuous)
+                                .fill(.ultraThinMaterial)
+                        }
+                        
+                }.listStyle(PlainListStyle())
+                    .padding(.top,120)
+            }.overlay{
                 if showWinAudio{
                     ReproductionView(mostrarButton: $mostrarButton, title: $audioL, cover: $covers)
-                        .padding(.top, -30)
+                        .padding(.top, 30)
                 }
+                
             }
-
         }
         
     }
 }
 
 #Preview {
-    CardListAudioView()
+    CardListAudioView(showListAudio: .constant(false))
 }

--- a/DrgonBallWiki/View/Cards/ReproductionView.swift
+++ b/DrgonBallWiki/View/Cards/ReproductionView.swift
@@ -53,7 +53,7 @@ struct ReproductionView: View {
                     .onTapGesture {
                         
                     }
-                
+               
                 Text(title)
                     .font(.custom("SaiyanSans", size: 50)).bold()
                     .foregroundStyle(Color.yellow)
@@ -67,6 +67,7 @@ struct ReproductionView: View {
                     ).padding(.horizontal, 3)
                     .shadow(radius: 10)
                 
+               
                 HStack{
                     Button(action: {
                         showStatus.toggle()
@@ -98,7 +99,8 @@ struct ReproductionView: View {
                     RoundedRectangle(cornerRadius: 15, style: .continuous)
                         .fill(.ultraThinMaterial)
                 }
-                .padding()
+            
+               .padding()
             
         }else{
             VStack{
@@ -133,11 +135,11 @@ struct ReproductionView: View {
                                 .frame(width: 50, height: 50)
                                 .padding(4)
                         })
-                        
+                        Spacer()
                         Text(title)
                             .modifier(StyleViewFont(size: 25, color: .red))
                             .padding(.horizontal, 5)
-                        
+                        Spacer()
                         Button(action: {
                             showStatus.toggle()
                             audioViewModel.tooglePlayback(for: showStatus == true ? .play : .pause, title: title)

--- a/DrgonBallWiki/View/Home.swift
+++ b/DrgonBallWiki/View/Home.swift
@@ -54,8 +54,11 @@ struct Home: View {
                 case .planets:
                     
                     ZStack{
-                        Image("Cosmos2").resizable().frame(width: .infinity, height: 1000, alignment: .center)
-                          
+                        Image("Cosmos2") 
+                                      .resizable()
+                                      .scaledToFill() // Escala la imagen para que llene todo el espacio
+                                      .frame(width: .infinity, height: .infinity) // Ajusta el tamaño de la imagen
+                                      .edgesIgnoringSafeArea(.all) // Ignora los bordes seguros y extiende la imagen a toda la pantalla
                         VStack{
                            
                             CardListPlanetesView(planets: planetsViewModel.allPlanets!)
@@ -66,7 +69,7 @@ struct Home: View {
                 }
                 
                 if showListAudio{
-                    CardListAudioView()
+                    CardListAudioView(showListAudio:  $showListAudio)
                         .matchedGeometryEffect(id: "reproduction", in: winAnimation)
                         .padding()
                 }
@@ -182,6 +185,13 @@ struct Home: View {
         }
         .overlay(alignment: .bottomLeading) {
             FloatingButton{
+                
+                FloatingAction(symbol: "iconoMusica") {
+                    withAnimation(.spring){
+                        showListAudio.toggle()
+                    }
+                }
+                
                 FloatingAction(symbol: "iconFavorito") {
                     withAnimation(.spring){
                         selectedView = .favoriteCharacters
@@ -200,11 +210,7 @@ struct Home: View {
                     }
                 }
                 
-                FloatingAction(symbol: "iconoMusica") {
-                    withAnimation(.spring){
-                        showListAudio.toggle()
-                    }
-                }
+              
                 
             } label: { isExpande in
                 Image("Ball1").resizable()


### PR DESCRIPTION
Se agrega un botón de cierre a la vista flotante, que muestra la lista de reproducción, se le agrega un encabezado, y se le soluciona el error de vista de tamaño negativo, así mismo también se soluciona un problema  al desplegar la lista en el apartado de planetas, la cual no se posicionaba  en el lugar requerido