### PR TITLE
Fix: audio player and invalid frame

### DIFF
--- a/DrgonBallWiki/View/Cards/CardListAudioView.swift
+++ b/DrgonBallWiki/View/Cards/CardListAudioView.swift
@@ -9,33 +9,34 @@ import SwiftUI
 import AVFAudio
 
 struct CardListAudioView: View {
-    
+
     @State private var viewModel = CardListAudioViewModel()
     @State private var audioL = ""
     @State private var covers = ""
-    @State private var showModal = false
     @State private var showWinAudio = false
     @State var mostrarButton = false
     @Binding var showListAudio: Bool
     @Namespace var winAnimation
-    
+
     var body: some View {
-        NavigationStack{
-            VStack{
+        NavigationStack {
+            VStack {
                 List {
-                    VStack(alignment: .leading){
-                        
-                        HStack(alignment: .firstTextBaseline){
+                    VStack(alignment: .leading) {
+
+                        HStack(alignment: .firstTextBaseline) {
                             Spacer()
                             Text("Lista de reproducciones")
                                 .modifier(StyleViewFont(size: 30, color: .red))
                                 .shadow(color: .cyan, radius: 5)
+
                             Spacer()
-                            Button(action: {
+
+                            Button {
                                 withAnimation(.spring(response: 0.3, dampingFraction: 1)) {
                                     showListAudio = false
                                 }
-                            }, label: {
+                            } label: {
                                 Image(systemName: "xmark")
                                     .font(.footnote)
                                     .fontWeight(.semibold)
@@ -44,10 +45,12 @@ struct CardListAudioView: View {
                                     .background {
                                         RoundedRectangle(cornerRadius: 100)
                                             .fill(.ultraThinMaterial)
-                                    }.padding()
-                            })
+                                    }
+                            }
                         }
+
                         Divider()
+
                         ForEach(viewModel.arrayOfSounds, id: \.self) { sound in
                             Text(sound.title)
                                 .modifier(StyleViewFont(size: 30, color: .red))
@@ -55,31 +58,42 @@ struct CardListAudioView: View {
                                 .onTapGesture {
                                     audioL = sound.title
                                     covers = sound.imageCoves
-                                    // showModal = true
-                                    mostrarButton = true
+
+                                    mostrarButton = false
+
                                     withAnimation(.spring( response: 0.5, dampingFraction: 0.8)){
                                         showWinAudio = true
+                                        mostrarButton = true
                                     }
                                 }
-                            
+
                         }
-                    }.listRowBackground(Color.clear)
-                        .background{
-                            RoundedRectangle(cornerRadius: 15, style: .continuous)
-                                .fill(.ultraThinMaterial)
-                        }
-                        
-                }.listStyle(PlainListStyle())
-                    .padding(.top,120)
-            }.overlay{
-                if showWinAudio{
-                    ReproductionView(mostrarButton: $mostrarButton, title: $audioL, cover: $covers)
-                        .padding(.top, 30)
+                    }
+                    .listRowBackground(Color.clear)
+                    .background {
+                        RoundedRectangle(cornerRadius: 15, style: .continuous)
+                            .fill(.ultraThinMaterial)
+                    }
+
                 }
-                
+                .listStyle(.plain)
+                .padding(.top, 120)
+            }
+            .overlay {
+                if showWinAudio {
+                    let audioViewModel = DetailAudioViewModel()
+
+                    ReproductionView(audioViewModel: audioViewModel, mostrarButton: $mostrarButton, title: $audioL, cover: $covers)
+                        .padding(.top, 30)
+                        .onChange(of: mostrarButton) {
+                            if !mostrarButton {
+                                audioViewModel.tooglePlayback(for: .stop, title: audioL)
+                            }
+                        }
+                }
             }
         }
-        
+
     }
 }
 

--- a/DrgonBallWiki/View/Cards/ReproductionView.swift
+++ b/DrgonBallWiki/View/Cards/ReproductionView.swift
@@ -8,32 +8,26 @@
 import SwiftUI
 
 struct ReproductionView: View {
-    
-    @State var audioViewModel = DetailAudioViewModel()
-    
-    @State private var showStatus = false
-    @State private var statusButtonStop = false
-    @State private var mostrarButtonMnu = true
+
+    @ObservedObject var audioViewModel: DetailAudioViewModel
+
     @Binding var mostrarButton: Bool
-    
     @Binding var title: String
     @Binding var cover: String
-    
+
     @Namespace var winAnimation
-    
+
     var body: some View {
-        if !mostrarButtonMnu {
-            VStack{
-                HStack{
-                    Button(action: {
-                        
-                        withAnimation(.spring( response: 0.5, dampingFraction: 0.8)){
-                            mostrarButtonMnu = true
+        if !audioViewModel.mostrarButtonMnu {
+            VStack {
+                HStack {
+                    Button {
+                        withAnimation(.spring( response: 0.5, dampingFraction: 0.8)) {
+                            audioViewModel.mostrarButtonMnu = true
                         }
-                        
-                    }, label: {
+                    } label: {
                         Image(systemName: "arrow.up.backward.and.arrow.down.forward")
-                            .symbolEffect(.bounce, value:  mostrarButtonMnu)
+                            .symbolEffect(.bounce, value:  audioViewModel.mostrarButtonMnu)
                             .font(.footnote)
                             .fontWeight(.semibold)
                             .foregroundStyle(Color.white)
@@ -42,18 +36,17 @@ struct ReproductionView: View {
                                 RoundedRectangle(cornerRadius: 300)
                                     .fill(.ultraThinMaterial)
                             }
-                    }).padding()
-                    
+                    }
+                    .padding()
+
                     Spacer()
                 }
+
                 Image(cover)
                     .resizable()
                     .frame(width: 300, height: 300)
                     .padding(4)
-                    .onTapGesture {
-                        
-                    }
-               
+
                 Text(title)
                     .font(.custom("SaiyanSans", size: 50)).bold()
                     .foregroundStyle(Color.yellow)
@@ -63,126 +56,130 @@ struct ReproductionView: View {
                             .font(.custom("SaiyanSans", size: 50)).bold()
                             .foregroundStyle(Color.red)
                             .offset(x: 3, y: 3)
-                        
-                    ).padding(.horizontal, 3)
+                    )
+                    .padding(.horizontal, 3)
                     .shadow(radius: 10)
-                
-               
+
                 HStack{
-                    Button(action: {
-                        showStatus.toggle()
-                        audioViewModel.tooglePlayback(for: showStatus == true ? .play : .pause, title: title)
-                    }, label: {
-                        
-                        Image(systemName: showStatus ? "pause.fill" : "play.fill")
+                    Button {
+                        audioViewModel.showStatus.toggle()
+                        audioViewModel.tooglePlayback(for: audioViewModel.showStatus ? .play : .pause, title: title)
+                    } label: {
+                        Image(systemName: audioViewModel.showStatus ? "pause.fill" : "play.fill")
                             .shadow(radius: 8)
-                            .symbolEffect(.bounce, value: showStatus)
+                            .symbolEffect(.bounce, value: audioViewModel.showStatus)
                             .font(.custom( "", size: 60))
-                            .foregroundStyle(showStatus ? Color.green : Color.primary)
-                    }).padding(.horizontal, -2)
-                    
-                    Button(action: {
-                        showStatus = false
+                            .foregroundStyle(audioViewModel.showStatus ? Color.green : Color.primary)
+                    }
+                    .padding(.horizontal, -2)
+
+                    Button {
+                        audioViewModel.showStatus = false
                         audioViewModel.tooglePlayback(for:  .stop, title: title)
-                    }, label: {
-                        
+                    } label: {
                         Image(systemName: "stop.fill")
                             .shadow(radius: 8)
-                            .symbolEffect(.bounce, value: statusButtonStop)
+                            .symbolEffect(.bounce, value: audioViewModel.statusButtonStop)
                             .font(.custom( "", size: 60))
-                            .foregroundStyle(showStatus ? Color.red : Color.primary)
-                        
-                    }).padding(.horizontal, 5)
-                }.padding()
-            }.matchedGeometryEffect(id: "reproduction", in: winAnimation)
-                .background{
-                    RoundedRectangle(cornerRadius: 15, style: .continuous)
-                        .fill(.ultraThinMaterial)
+                            .foregroundStyle(audioViewModel.showStatus ? Color.red : Color.primary)
+
+                    }
+                    .padding(.horizontal, 5)
                 }
-            
-               .padding()
-            
-        }else{
-            VStack{
-                if mostrarButton == true {
-                    HStack{
-                        Button(action: {
-                            withAnimation(.spring( response: 0.5, dampingFraction: 0.8)){
+                .padding()
+            }
+            .matchedGeometryEffect(id: "reproduction", in: winAnimation)
+            .background{
+                RoundedRectangle(cornerRadius: 15, style: .continuous)
+                    .fill(.ultraThinMaterial)
+            }
+            .padding()
+
+        } else {
+            VStack {
+                if mostrarButton {
+                    HStack {
+                        Button {
+                            withAnimation(.spring( response: 0.5, dampingFraction: 0.8)) {
+                                audioViewModel.tooglePlayback(for: .stop, title: title)
                                 mostrarButton = false
+                                audioViewModel.showStatus = false
                             }
-                        }, label: {
+                        } label: {
                             Image(systemName: "xmark")
                                 .font(.footnote)
                                 .fontWeight(.semibold)
                                 .foregroundStyle(Color.white)
                                 .padding(7)
-                            
+
                                 .background{
                                     RoundedRectangle(cornerRadius: 100)
                                         .fill(.ultraThinMaterial)
                                 }
-                            
                                 .padding(9)
-                        })
-                        
-                        Button(action: {
+                        }
+
+                        Button {
                             withAnimation(.spring( response: 0.5, dampingFraction: 0.8)){
-                                mostrarButtonMnu = false
+                                audioViewModel.mostrarButtonMnu = false
                             }
-                        }, label: {
+                        } label: {
                             Image(cover)
                                 .resizable()
                                 .frame(width: 50, height: 50)
                                 .padding(4)
-                        })
+                        }
+
                         Spacer()
+
                         Text(title)
                             .modifier(StyleViewFont(size: 25, color: .red))
                             .padding(.horizontal, 5)
+
                         Spacer()
-                        Button(action: {
-                            showStatus.toggle()
-                            audioViewModel.tooglePlayback(for: showStatus == true ? .play : .pause, title: title)
-                        }, label: {
-                            
-                            Image(systemName: showStatus ? "pause.fill" : "play.fill")
+
+                        Button {
+                            audioViewModel.showStatus.toggle()
+                            audioViewModel.tooglePlayback(for: audioViewModel.showStatus ? .play : .pause, title: title)
+                        } label: {
+                            Image(systemName: audioViewModel.showStatus ? "pause.fill" : "play.fill")
                                 .shadow(radius: 8)
-                                .symbolEffect(.bounce, value: showStatus)
+                                .symbolEffect(.bounce, value: audioViewModel.showStatus)
                                 .font(.custom( "", size: 30))
-                                .foregroundStyle(showStatus ? Color.green : Color.primary)
-                        }).padding(.horizontal, -2)
-                        
-                        Button(action: {
-                            showStatus = false
+                                .foregroundStyle(audioViewModel.showStatus ? Color.green : Color.primary)
+                        }
+                        .padding(.horizontal, -2)
+
+                        Button {
+                            audioViewModel.showStatus = false
                             audioViewModel.tooglePlayback(for:  .stop, title: title)
-                        }, label: {
-                            
+                        } label: {
                             Image(systemName: "stop.fill")
                                 .shadow(radius: 8)
-                                .symbolEffect(.bounce, value: statusButtonStop)
+                                .symbolEffect(.bounce, value: audioViewModel.statusButtonStop)
                                 .font(.custom( "", size: 30))
-                                .foregroundStyle(showStatus ? Color.red : Color.primary)
-                            
-                        }).padding(.horizontal, 5)
-                        
-                    }.matchedGeometryEffect(id: "reproduction", in: winAnimation)
-                        .background{
-                            RoundedRectangle(cornerRadius: 15, style: .continuous)
-                                .fill(.ultraThinMaterial)
+                                .foregroundStyle(audioViewModel.showStatus ? Color.red : Color.primary)
+
                         }
-                        .padding()
-                       
+                        .padding(.horizontal, 5)
+
+                    }
+                    .matchedGeometryEffect(id: "reproduction", in: winAnimation)
+                    .background {
+                        RoundedRectangle(cornerRadius: 15, style: .continuous)
+                            .fill(.ultraThinMaterial)
+                    }
+                    .padding()
+
                     Spacer()
                 }
             }
         }
-        
     }
-    
-    
 }
 
 #Preview {
-    
-    ReproductionView(mostrarButton: .constant(true), title: .constant("Dagon Ball") , cover: .constant("DragonBall_CD"))
+    let detailAudioViewModel = DetailAudioViewModel()
+
+    return ReproductionView(audioViewModel: detailAudioViewModel, mostrarButton: .constant(true), title: .constant("Dagon Ball") , cover: .constant("DragonBall_CD"))
 }

--- a/DrgonBallWiki/View/Home.swift
+++ b/DrgonBallWiki/View/Home.swift
@@ -52,23 +52,21 @@ struct Home: View {
                         .environment(singleCharacterViewModel)
                         .padding(.horizontal, 30)
                 case .planets:
-                    
-                    ZStack{
-                        Image("Cosmos2") 
-                                      .resizable()
-                                      .scaledToFill() // Escala la imagen para que llene todo el espacio
-                                      .frame(width: .infinity, height: .infinity) // Ajusta el tamaño de la imagen
-                                      .edgesIgnoringSafeArea(.all) // Ignora los bordes seguros y extiende la imagen a toda la pantalla
-                        VStack{
-                           
+                    ZStack {
+                        Image("Cosmos2")
+                            .resizable()
+                            .scaledToFill() // Escala la imagen para que llene todo el espacio
+                            .frame(maxWidth: .infinity, maxHeight: .infinity) // Ajusta el tamaño de la imagen
+                            .edgesIgnoringSafeArea(.all) // Ignora los bordes seguros y extiende la imagen a toda la pantalla
+                        VStack {
                             CardListPlanetesView(planets: planetsViewModel.allPlanets!)
                                
-                        }.frame(width: .infinity, height: 680, alignment: .center)
+                        }
+                        .frame(maxWidth: .infinity, maxHeight: 680, alignment: .center)
                     }
-                    
                 }
                 
-                if showListAudio{
+                if showListAudio {
                     CardListAudioView(showListAudio:  $showListAudio)
                         .matchedGeometryEffect(id: "reproduction", in: winAnimation)
                         .padding()

--- a/DrgonBallWiki/ViewModel/DetailAudioViewModel.swift
+++ b/DrgonBallWiki/ViewModel/DetailAudioViewModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import AVFAudio
-
+import SwiftUI
 
 enum PlayStatus {
     case play
@@ -15,32 +15,34 @@ enum PlayStatus {
     case stop
 }
 
-@Observable
-class DetailAudioViewModel{
-    
-    
+final class DetailAudioViewModel: ObservableObject {
+
+    @Published var showStatus = false
+    @Published var statusButtonStop = false
+    @Published var mostrarButtonMnu = true
+
     //Audio player
-    var audioPlayer: AVAudioPlayer?
-    var time: Double = 0.0
-    var currentTime: TimeInterval = 0
-    var isPlay = false
-    
+    private var audioPlayer: AVAudioPlayer?
+    private var time: Double = 0.0
+    private var currentTime: TimeInterval = 0
+    private var isPlay = false
+
     /// Función de reproducción
-    func playAudio(_ url: String){
+    func playAudio(_ url: String) {
         guard let audioData = Bundle.main.url(forResource: url , withExtension: "mp3") else {
             print("audios no disponibles")
             return
         }
-        
-            audioPlayer = try! AVAudioPlayer(contentsOf: audioData)
-            audioPlayer?.currentTime = time
-            audioPlayer?.prepareToPlay()
-            audioPlayer?.play()
-            isPlay = true
-            print("reproduciendo audio ...")
-        
+
+        audioPlayer = try! AVAudioPlayer(contentsOf: audioData)
+        audioPlayer?.currentTime = time
+        audioPlayer?.prepareToPlay()
+        audioPlayer?.play()
+        isPlay = true
+        print("reproduciendo audio ...")
+
     }
-    
+
     /// Pausar el audio
     func pauseAudio() {
         audioPlayer?.pause()
@@ -48,24 +50,24 @@ class DetailAudioViewModel{
         isPlay = false
         print("Audio pausado")
     }
-    
+
     /// Parar el audio
-    func stopAudio(){
+    func stopAudio() {
         time = 0.0
         audioPlayer?.prepareToPlay()
         audioPlayer?.stop()
         isPlay = false
         print("Audio Detenido")
     }
-    
-    func tooglePlayback(for audio: PlayStatus, title: String){
-            switch audio{
-            case .play:
-                playAudio(title)
-            case .pause:
-                pauseAudio()
-            case .stop:
-                stopAudio()
-            }
+
+    func tooglePlayback(for audio: PlayStatus, title: String) {
+        switch audio {
+        case .play:
+            playAudio(title)
+        case .pause:
+            pauseAudio()
+        case .stop:
+            stopAudio()
+        }
     }
 }


### PR DESCRIPTION
Fixes:
- En Home estaba dando alertas purpuras por frame invalido en la imagen de fondo de los planetas 
- En el reproductor de audio no se estaba pausando al seleccionar otro audio en la lista 
- Al cerrar `ReproductionView` no se estaba pausando el audio 
- Refactor de codigo y uso de inyección de dependencias para `ReproductionView`
- Identado de codigo


Todos mis cambios se basaron sobre esta vista

![image](https://github.com/lordzzz777/DrgonBallWiki/assets/100188413/6040d5e2-8ff6-47cb-bc91-cfadf00fbcdd)

Pruebas de las alertas purpuras 

![Screenshot 2024-05-22 at 3 49 53 PM](https://github.com/lordzzz777/DrgonBallWiki/assets/100188413/2d33c8db-856d-4360-859a-388d8ab45784)
